### PR TITLE
Providing non-zero default for newVersion

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -80,6 +80,7 @@ func RunMigrations(db DB, migrations []Migration, a ...string) (oldVersion, newV
 	if err != nil {
 		return
 	}
+	newVersion = oldVersion
 
 	switch cmd {
 	case "create":


### PR DESCRIPTION
If there are no new migrations to run, then running `init` or `up` will produce misleading output because `newVersion` currently defaults to 0; eg:
```bash
$ go run *.go up
Migrated from version 3 to 0
```
By defaulting `newVersion` to `oldVersion`, if there is nothing to do then the versions match.
