### PR TITLE
Removing mention of init command in example/main.go

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -10,7 +10,6 @@ import (
 )
 
 const usageText = `This program runs command on the db. Supported commands are:
-  - init - creates gopg_migrations table.
   - up - runs all available migrations.
   - down - reverts last migration.
   - reset - reverts all migrations.


### PR DESCRIPTION
The current `example/main.go` file still mentions the `init` command, which no longer exists.