### PR TITLE
Add GetRegisteredMigrations() function

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -45,6 +45,14 @@ func Register(up, down func(DB) error) error {
 	return nil
 }
 
+// Return all currently registered Migration objects.
+func GetRegisteredMigrations() []Migration {
+	// Make a copy to avoid side effects.
+	migrations := make([]Migration, len(allMigrations))
+	copy(migrations, allMigrations)
+	return migrations
+}
+
 // Run runs command on the db. Supported commands are:
 // - up - runs all available migrations.
 // - down - reverts last migration.


### PR DESCRIPTION
Hello,

I needed to expose the list of Migration objects to run some manually and or get the highest registered version. Seemed better to just expose the list since it's registered and versions are already parsed. 

You can now run this:

```go
allMigrations := migrations.GetRegisteredMigrations()
```

... and you'll get a copy of the internal `allMigrations` var.