### PR TITLE
Automatically discover migrations in *.sql files

### DIFF
--- a/example/4_delete_value.down.sql
+++ b/example/4_delete_value.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM my_table WHERE id = 2;

--- a/example/4_insert_value.up.sql
+++ b/example/4_insert_value.up.sql
@@ -1,0 +1,1 @@
+INSERT INTO my_table VALUES (2);

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,5 @@
 package migrations
 
 func Set(ms []Migration) {
-	allMigrations = ms
+	g.migrations = ms
 }


### PR DESCRIPTION
Closes https://github.com/go-pg/migrations/pull/25
Fixes https://github.com/go-pg/migrations/issues/22