### PR TITLE
Check if info is nil before running info.IsDir()

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -110,7 +110,7 @@ func discoverSQLMigrations(file string) error {
 	}
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
+		if info == nil || info.IsDir() {
 			return nil
 		}
 		if !strings.HasSuffix(path, ".sql") {


### PR DESCRIPTION
Fixes an issue where `info.IsDir()` panics if there is no directory containing migrations.

### Background

Prior to #31, the migrations were always part of the compiled Go binary, as only Go files were permitted for defining migrations. With #31 however, now SQL files are permitted. This change, as you know, required a way to find those SQL files, which was achieved with the `filepath.Walk` function.

This change however causes a bug for users who need to run their compiled binary without their migrations files available. This is my usecase -- I typically cross-compile a binary on a CI machine, and then rsync that binary to a remote server in order to deploy my application. The bug arises in the `info.IsDir` call. If `info.IsDir()` is called but `info` is nil (which is the case when the `dir` argument is not a valid directory), the `IsDir()` call causes a panic.

### Fix

This is easily fixed by first checking if `info` is nil before running the `IsDir()` function.

In the future, a better check might be to handle the `err` argument, as in this specific case, the `err` contains an error with a message that's something like,

```
lstat: <dir> is not a directory
```

I went with my approach however since it is the smallest possible change to get my code and usecase working again, and is what I've done before for a similar issue.