### PR TITLE
Fix #37: Add Group for configurable groups.

### DIFF
--- a/db.go
+++ b/db.go
@@ -8,38 +8,29 @@ import (
 	"github.com/go-pg/pg/types"
 )
 
-var defaultTableName = "gopg_migrations"
-
 func SetTableName(name string) {
-	defaultTableName = name
-}
-
-func (g *Group) tableName() string {
-	if g.TableName == "" {
-		return defaultTableName
-	}
-	return g.TableName
+	DefaultCollection = DefaultCollection.WithTableName(name)
 }
 
 type DB = orm.DB
 
-func (g *Group) getTableName() types.ValueAppender {
-	return pg.Q(g.tableName())
+func (c *collection) getTableName() types.ValueAppender {
+	return pg.Q(c.tableName)
 }
 
 func Version(db DB) (int64, error) {
-	return DefaultGroup.Version(db)
+	return DefaultCollection.Version(db)
 }
 
-func (g *Group) Version(db DB) (int64, error) {
-	if err := g.createTables(db); err != nil {
+func (c *collection) Version(db DB) (int64, error) {
+	if err := c.createTables(db); err != nil {
 		return 0, err
 	}
 
 	var version int64
 	_, err := db.QueryOne(pg.Scan(&version), `
 		SELECT version FROM ? ORDER BY id DESC LIMIT 1
-	`, g.getTableName())
+	`, c.getTableName())
 	if err != nil {
 		if err == pg.ErrNoRows {
 			return 0, nil
@@ -50,23 +41,23 @@ func (g *Group) Version(db DB) (int64, error) {
 }
 
 func SetVersion(db DB, version int64) error {
-	return DefaultGroup.SetVersion(db, version)
+	return DefaultCollection.SetVersion(db, version)
 }
 
-func (g *Group) SetVersion(db DB, version int64) error {
-	if err := g.createTables(db); err != nil {
+func (c *collection) SetVersion(db DB, version int64) error {
+	if err := c.createTables(db); err != nil {
 		return err
 	}
 
 	_, err := db.Exec(`
 		INSERT INTO ? (version, created_at) VALUES (?, now())
-	`, g.getTableName(), version)
+	`, c.getTableName(), version)
 	return err
 }
 
-func (g *Group) createTables(db DB) error {
-	if ind := strings.IndexByte(g.tableName(), '.'); ind >= 0 {
-		_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.Q(g.tableName()[:ind]))
+func (c *collection) createTables(db DB) error {
+	if ind := strings.IndexByte(c.tableName, '.'); ind >= 0 {
+		_, err := db.Exec(`CREATE SCHEMA IF NOT EXISTS ?`, pg.Q(c.tableName[:ind]))
 		if err != nil {
 			return err
 		}
@@ -78,6 +69,6 @@ func (g *Group) createTables(db DB) error {
 			version bigint,
 			created_at timestamptz
 		)
-	`, g.getTableName())
+	`, c.getTableName())
 	return err
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,5 @@
 package migrations
 
 func Set(ms []Migration) {
-	DefaultGroup.migrations = ms
+	DefaultCollection = DefaultCollection.WithRegisteredMigrations(ms)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,5 @@
 package migrations
 
 func Set(ms []Migration) {
-	g.migrations = ms
+	DefaultGroup.migrations = ms
 }


### PR DESCRIPTION
Support registering and running multiple groups of migrations in the
same process, with configurable registration behavior and migration
table name per group.