### PR TITLE
Only create gopg_migrations table if not exists

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -582,7 +582,7 @@ func (c *Collection) createTable(db DB) error {
 	}
 
 	_, err := db.Exec(`
-		CREATE TABLE ? (
+		CREATE TABLE IF NOT EXISTS ? (
 			id serial,
 			version bigint,
 			created_at timestamptz


### PR DESCRIPTION
Removed in #46 
Line:  https://github.com/go-pg/migrations/pull/46/files#diff-fd7790e1c0a568c313c0da1f44046b52L564

After updating to the latest version, I had to start running the "init" command on a clean database or otherwise face `gopg_migrations does not exist, have you run init?` 

When trying to automate the migrations on app start up with something like: 
```
oldVersion, newVersion, err := migrations.Run(db, "init", "up")
```

First run would be fine, but subsequent resulted in the table already existing.
So, I think it would make sense to add back `IF NOT EXISTS` to the create gopg_migrations table for those who might want to automate that creation.

If I missed the desired way way to create this table without running `init` manually please let me know! 

