### PR TITLE
Allow schema to be explicitly set

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -152,6 +152,7 @@ func TestSetSchema(t *testing.T) {
 		{"default schema", "", "public", "gopg_migrations"},
 		{"set specific schema", "testschema", "testschema", "gopg_migrations"},
 	}
+
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 


### PR DESCRIPTION
Hi! I hope this PR makes sense.

We were running into issues running migrations during unit tests due to the hard-coded nature of the `public` schema in the current version.

This feature allows allows the user to set which schema to actually use, in case they care to.

I've continued to use `public` as the default, so there shouldn't be any breaking changes. 

Let me know if you have any feedback. Thanks!