### PR TITLE
Add init option description to the example 

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -10,6 +10,7 @@ import (
 )
 
 const usageText = `This program runs command on the db. Supported commands are:
+  - init - creates version info table in the database
   - up - runs all available migrations.
   - up [target] - runs available migrations up to the target one.
   - down - reverts last migration.


### PR DESCRIPTION
Add a simple description of 'init' option to the example.
Close #63 