### PR TITLE
"init" command no longer fails if called twice

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -649,7 +649,7 @@ func (c *Collection) createTable(db DB) error {
 	}
 
 	_, err := db.Exec(`
-		CREATE TABLE ? (
+		CREATE TABLE IF NOT EXISTS ? (
 			id serial,
 			version bigint,
 			created_at timestamptz


### PR DESCRIPTION
Done by using `CREATE TABLE IF NOT EXISTS` instead of just `CREATE TABLE` in `collection.createTable`

Rationale: when you implement continuous delivery with
different environments, you can run `migrator init` at each deployment
without having it fail.