### PR TITLE
Add log on failed migrations validation

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -382,6 +382,7 @@ func (c *Collection) Run(db DB, a ...string) (oldVersion, newVersion int64, err 
 	migrations := c.Migrations()
 	err = validateMigrations(migrations)
 	if err != nil {
+		fmt.Println(fmt.Sprintf("migrations validation failed: %s", err.Error()))
 		return
 	}
 


### PR DESCRIPTION
Simply adds a log when migrations validation fails