### PR TITLE
Allow collection.Version() calls during a migration

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -680,7 +680,7 @@ func (c *Collection) begin(db DB) (*pg.Tx, int64, error) {
 	}
 	// If there is an error setting this, rollback the transaction and don't bother doing it
 	// because neither CockroachDB nor Yugabyte support it
-	_, err = tx.Exec("LOCK TABLE ?", pg.SafeQuery(c.tableName))
+	_, err = tx.Exec("LOCK TABLE ? IN EXCLUSIVE MODE", pg.SafeQuery(c.tableName))
 	if err != nil {
 		_ = tx.Rollback()
 


### PR DESCRIPTION
As of today, if you try to call `collection.Version(db)` when a migration is running, it will wait for the `LOCK TABLE gopg_migrations` lock to be released before returning.

If you have long-running migrations (e.g. `CREATE INDEX CONCURRENTLY ...` that is running in background) and other pieces of code that rely on getting the current database version, this becomes a problem.

I stumbled upon this issue when trying to start services that checked the current database version at startup while a long-running migration was executed.

To allow this use case, we can update the lock command to `LOCK TABLE ? IN EXCLUSIVE MODE` which allows concurrent SELECT commands to be run on the migrations table, while still forbidding other operations.

From the documentation:

>  The EXCLUSIVE mode allows only concurrent ACCESS SHARE locks, i.e., only reads from the table can proceed in parallel with a transaction holding this lock mode.

See:
* https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-TABLES
* https://www.postgresql.org/docs/12/sql-lock.html

I've targeted the `v7` branch for this patch, since `v8` is not released yet. I can update this pull request if this is not the best target.

Thanks,